### PR TITLE
Added support for terminals without Emojis.

### DIFF
--- a/src/services/tables/builders/PriceEstimatesTableBuilder.js
+++ b/src/services/tables/builders/PriceEstimatesTableBuilder.js
@@ -6,8 +6,32 @@ import Table from 'cli-table2';
 
 import Utilities from '../../../Utilities';
 
+var emojiCarType = emoji.get('oncoming_automobile');
+var emojiPrice = emoji.get('money_with_wings');
+var emojiDistance = emoji.get('arrows_clockwise');
+var emojiETA = emoji.get('hourglass_flowing_sand');
+var emojiBoom = emoji.get('boom');
+var emojiNo = emoji.get('no_entry_sign');
+var emojiSurgePresent = emoji.get('grimacing');
+var emojiDestination = emoji.get('end');
+var emojiStartLocation = emoji.get('round_pushpin');
+
+
+
 export default class PriceEstimatesTableBuilder {
   static build(estimates) {
+     if(emojiSupportedOSList.indexOf(process.platform)<0) {
+      emojiCarType = 'Car Type ';
+      emojiPrice = 'Price ';
+      emojiDistance = 'Distance ';
+      emojiETA = 'ETA ';
+      emojiBoom = '*';
+      emojiNo = 'No ';
+      emojiSurgePresent = 'Yes';
+      emojiDestination = 'Destination ';
+      emojiStartLocation = 'Start Location ';
+    }
+
     let table = PriceEstimatesTableBuilder.buildInitialTable();
     estimates.estimates.forEach(estimate => {
       if (estimate.productName !== 'TAXI') {
@@ -21,11 +45,11 @@ export default class PriceEstimatesTableBuilder {
 
   static getTableHeaders() {
     return List.of(
-      emoji.get('oncoming_automobile'),
-      emoji.get('money_with_wings'),
-      emoji.get('arrows_clockwise'),
-      emoji.get('hourglass_flowing_sand'),
-      `${emoji.get('boom')} Surge${emoji.get('boom')}`
+      emojiCarType,
+      emojiPrice,
+      emojiDistance,
+      emojiETA,
+      `${emojiBoom} Surge${emojiBoom}`
     );
   }
 
@@ -49,14 +73,14 @@ export default class PriceEstimatesTableBuilder {
 
   static buildSurgeMultiplierSymbol(surgeMultiplier) {
     return surgeMultiplier === 1
-      ? emoji.get('no_entry_sign')
-      : `${surgeMultiplier}x ${emoji.get('grimacing')}`;
+      ? emojiNo
+      : `${surgeMultiplier}x ${emojiCarType}`;
   }
 
   static buildLocationRow(name, isEnd) {
     let symbol = isEnd
-      ? emoji.get('end')
-      : emoji.get('round_pushpin');
+      ? emojiDestination
+      : emojiStartLocation;
     return [
       {
         colSpan: 1,
@@ -70,3 +94,4 @@ export default class PriceEstimatesTableBuilder {
     ]
   }
 }
+

--- a/src/services/tables/builders/PriceEstimatesTableBuilder.js
+++ b/src/services/tables/builders/PriceEstimatesTableBuilder.js
@@ -15,6 +15,7 @@ var emojiNo = emoji.get('no_entry_sign');
 var emojiSurgePresent = emoji.get('grimacing');
 var emojiDestination = emoji.get('end');
 var emojiStartLocation = emoji.get('round_pushpin');
+var emojiSupportedOSList = ['darwin'];
 
 
 

--- a/src/services/tables/builders/TimeEstimatesTableBuilder.js
+++ b/src/services/tables/builders/TimeEstimatesTableBuilder.js
@@ -6,8 +6,19 @@ import Table from 'cli-table2';
 
 import Utilities from '../../../Utilities';
 
+var emojiETA = emoji.get('hourglass_flowing_sand');
+var emojiCarType = emoji.get('oncoming_automobile');
+var emojiLocation = emoji.get('round_pushpin');
+var emojiSupportedOSList = ['darwin'];
+
 export default class TimeEstimatesTableBuilder {
   static build(estimates) {
+    if(emojiSupportedOSList.indexOf(process.platform)<0) {
+      emojiETA = 'ETA ';
+      emojiCarType = 'Car Type ';
+      emojiLocation = 'Location : ';
+    }
+
     let table = TimeEstimatesTableBuilder.buildInitialTable(estimates.location.name);
     TimeEstimatesTableBuilder.groupByTimeEstimate(estimates.estimates)
                              .entrySeq()
@@ -17,8 +28,8 @@ export default class TimeEstimatesTableBuilder {
 
   static getTableHeaders() {
     return List.of(
-      emoji.get('hourglass_flowing_sand'),
-      emoji.get('oncoming_automobile')
+      emojiETA,
+      emojiCarType
     );
   }
 
@@ -26,7 +37,7 @@ export default class TimeEstimatesTableBuilder {
     let table = new Table();
     table.push([{
       colSpan: 2,
-      content: `${emoji.get('round_pushpin')} ${locationName}`,
+      content: `${emojiLocation} ${locationName}`,
       hAlign: 'center'
     }]);
     let formattedHeaders = List(TimeEstimatesTableBuilder.getTableHeaders()
@@ -49,3 +60,4 @@ export default class TimeEstimatesTableBuilder {
     return timeEstimateGroups;
   }
 }
+


### PR DESCRIPTION
Trying to fix the headers not being displayed [issue](https://github.com/jaebradley/uber-cli/issues/22). It determines whether emojis are supported or not by checking OS type. Only Mac OS is assumed to support emojis but we can easily add other OS'es that might support emojis. 