### PR TITLE
Add distance conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cli-table2": "^0.2.0",
     "colors": "^1.1.2 ",
     "commander": "^2.9.0",
+    "convert-units": "^2.0.1",
     "currency-symbol-map": "^3.1.0",
     "immutable": "^3.8.1",
     "node-emoji": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "commander": "^2.9.0",
     "convert-units": "^2.0.1",
     "currency-symbol-map": "^3.1.0",
+    "enumify": "^1.0.4",
     "immutable": "^3.8.1",
     "node-emoji": "^1.4.3",
     "uber-client": "^0.0.2"

--- a/src/data/Distance.js
+++ b/src/data/Distance.js
@@ -1,0 +1,12 @@
+'use es6';
+
+import { Record } from 'immutable';
+
+import DistanceUnit from './DistanceUnit';
+
+const defaults = {
+  value: 0,
+  unit: DistanceUnit.MILE
+};
+
+export default class Distance extends Record(defaults) {}

--- a/src/data/DistanceUnit.js
+++ b/src/data/DistanceUnit.js
@@ -1,0 +1,7 @@
+'use es6';
+
+import { Enum } from 'enumify';
+
+export default class DistanceUnit extends Enum {}
+
+DistanceUnit.init(['MILE', 'KILOMETER']);

--- a/src/data/DistanceUnit.js
+++ b/src/data/DistanceUnit.js
@@ -4,4 +4,4 @@ import { Enum } from 'enumify';
 
 export default class DistanceUnit extends Enum {}
 
-DistanceUnit.init(['MILE', 'KILOMETER']);
+DistanceUnit.initEnum(['MILE', 'KILOMETER']);

--- a/src/data/PriceEstimate.js
+++ b/src/data/PriceEstimate.js
@@ -3,12 +3,13 @@
 import {Record} from 'immutable';
 import CurrencySymbol from 'currency-symbol-map';
 
+import Distance from './Distance';
 import Range from './Range';
 
 let defaults = {
   productName: '',
   // in miles
-  distance: 0,
+  distance: new Distance(),
   range: new Range(),
   // in seconds
   duration: 0,

--- a/src/data/PriceEstimate.js
+++ b/src/data/PriceEstimate.js
@@ -22,8 +22,4 @@ export default class PriceEstimate extends Record(defaults) {
   getFormattedRange() {
     return `${CurrencySymbol(this.currencyCode)}${this.range.low}-${CurrencySymbol(this.currencyCode)}${this.range.high}`;
   }
-
-  getFormattedDistance() {
-    return `${this.distance} mi.`;
-  }
 }

--- a/src/data/PriceEstimate.js
+++ b/src/data/PriceEstimate.js
@@ -8,7 +8,6 @@ import Range from './Range';
 
 let defaults = {
   productName: '',
-  // in miles
   distance: new Distance(),
   range: new Range(),
   // in seconds

--- a/src/data/PriceEstimateQuery.js
+++ b/src/data/PriceEstimateQuery.js
@@ -11,4 +11,16 @@ const defaults = {
 };
 
 export default class PriceEstimateQuery extends Record(defaults) {
+  static from(startAddress, endAddress, distanceUnitName) {
+    const distanceUnit = DistanceUnit.enumValueOf(distanceUnitName.toUpperCase());
+    if (typeof distanceUnit == 'undefined') {
+      throw new TypeError('Unknown distance unit');
+    }
+
+    return new PriceEstimateQuery({
+      startAddress: startAddress,
+      endAddress: endAddress,
+      distanceUnit: distanceUnit
+    });
+  }
 }

--- a/src/data/PriceEstimateQuery.js
+++ b/src/data/PriceEstimateQuery.js
@@ -12,9 +12,12 @@ const defaults = {
 
 export default class PriceEstimateQuery extends Record(defaults) {
   static from(startAddress, endAddress, distanceUnitName) {
-    const distanceUnit = DistanceUnit.enumValueOf(distanceUnitName.toUpperCase());
-    if (typeof distanceUnit == 'undefined') {
-      throw new TypeError('Unknown distance unit');
+    let distanceUnit = DistanceUnit.MILE;
+    if (typeof distanceUnitName !== 'undefined') {
+      distanceUnit = DistanceUnit.enumValueOf(distanceUnitName.toUpperCase());
+      if (typeof distanceUnit == 'undefined') {
+        throw new TypeError('Unknown distance unit');
+      }
     }
 
     return new PriceEstimateQuery({

--- a/src/data/PriceEstimateQuery.js
+++ b/src/data/PriceEstimateQuery.js
@@ -1,0 +1,14 @@
+'use es6';
+
+import { Record } from 'immutable';
+
+import DistanceUnit from './DistanceUnit';
+
+const defaults = {
+  startAddress: '',
+  endAddress: '',
+  distanceUnit: DistanceUnit.MILE
+};
+
+export default class PriceEstimateQuery extends Record(defaults) {
+}

--- a/src/executables/uber-price.js
+++ b/src/executables/uber-price.js
@@ -9,10 +9,11 @@ let service = new CommandExecutionService();
 program
   .option('-s, --start <start>', 'specify start address')
   .option('-e, --end <end>', 'specify end address')
+  .option('-u, --unit <unit>', 'specify distance unit')
   .parse(process.argv);
 
 try {
-  service.executePriceEstimates(program.start, program.end)
+  service.executePriceEstimates(program.start, program.end, program.unit)
          .then(table => console.log(table));
 } catch (Error) {
   console.error('Could not get price estimates');

--- a/src/services/CommandExecutionService.js
+++ b/src/services/CommandExecutionService.js
@@ -3,6 +3,7 @@
 import program from 'commander';
 
 import DistanceUnit from '../data/DistanceUnit';
+import PriceEstimateQuery from '../data/PriceEstimateQuery';
 import UberService from './UberService';
 import PriceEstimatesTableBuilder from './tables/builders/PriceEstimatesTableBuilder';
 import TimeEstimatesTableBuilder from './tables/builders/TimeEstimatesTableBuilder';
@@ -12,21 +13,17 @@ export default class CommandExecutionService {
     this.uberService = new UberService();
   }
 
-  executePriceEstimates(start, end, distanceUnitName) {
-    if (typeof start !== 'string') {
+  executePriceEstimates(startAddress, endAddress, distanceUnitName) {
+    if (typeof startAddress !== 'string') {
       throw new TypeError('start address should be a string');
     }
 
-    if (typeof end !== 'string') {
+    if (typeof endAddress !== 'string') {
       throw new TypeError('end address should be a string');
     }
 
-    let distanceUnit = DistanceUnit.MILE;
-    if (typeof distanceUnitName === 'string') {
-      distanceUnit = DistanceUnit.enumValueOf(distanceUnitName.toUpperCase());
-    }
-
-    return this.uberService.getPriceEstimates(start, end, distanceUnit)
+    const query = PriceEstimateQuery.from(startAddress, endAddress, distanceUnitName);
+    return this.uberService.getPriceEstimates(query)
                            .then(estimates => PriceEstimatesTableBuilder.build(estimates));
   }
 

--- a/src/services/CommandExecutionService.js
+++ b/src/services/CommandExecutionService.js
@@ -2,6 +2,7 @@
 
 import program from 'commander';
 
+import DistanceUnit from '../data/DistanceUnit';
 import UberService from './UberService';
 import PriceEstimatesTableBuilder from './tables/builders/PriceEstimatesTableBuilder';
 import TimeEstimatesTableBuilder from './tables/builders/TimeEstimatesTableBuilder';
@@ -11,7 +12,7 @@ export default class CommandExecutionService {
     this.uberService = new UberService();
   }
 
-  executePriceEstimates(start, end) {
+  executePriceEstimates(start, end, distanceUnitName) {
     if (typeof start !== 'string') {
       throw new TypeError('start address should be a string');
     }
@@ -20,7 +21,12 @@ export default class CommandExecutionService {
       throw new TypeError('end address should be a string');
     }
 
-    return this.uberService.getPriceEstimates(start, end)
+    let distanceUnit = DistanceUnit.MILE;
+    if (typeof distanceUnitName === 'string') {
+      distanceUnit = DistanceUnit.enumValueOf(distanceUnitName.toUpperCase());
+    }
+
+    return this.uberService.getPriceEstimates(start, end, distanceUnit)
                            .then(estimates => PriceEstimatesTableBuilder.build(estimates));
   }
 

--- a/src/services/DistanceConverter.js
+++ b/src/services/DistanceConverter.js
@@ -12,18 +12,18 @@ export default class DistanceConverter {
     const convertedValue = convert(distance.value).from(fromUnitIdentifier).to(toUnitIdentifier);
 
     switch (toUnit) {
-      case Unit.KILOMETER: {
+      case DistanceUnit.KILOMETER: {
         // Note divided by 1000 because convert library does not have kilometers, so using meters
         return new Distance({
           value: convertedValue / 1000,
-          unit: Unit.KILOMETER
+          unit: DistanceUnit.KILOMETER
         });
       }
 
-      case Unit.MILE: {
+      case DistanceUnit.MILE: {
         return new Distance({
           value: convertedValue,
-          unit: Unit.MILE
+          unit: DistanceUnit.MILE
         });
       }
 
@@ -35,11 +35,11 @@ export default class DistanceConverter {
 
   static getUnitConversionIdentifier(unit) {
     switch (unit) {
-      case Unit.MILE: {
+      case DistanceUnit.MILE: {
         return 'mi';
       }
 
-      case Unit.KILOMETER: {
+      case DistanceUnit.KILOMETER: {
         return 'm';
       }
 

--- a/src/services/DistanceConverter.js
+++ b/src/services/DistanceConverter.js
@@ -1,0 +1,51 @@
+'use es6';
+
+import convert from 'convert-units';
+
+import Distance from '../data/Distance';
+import DistanceUnit from '../data/DistanceUnit';
+
+export default class DistanceConverter {
+  static convert(distance, toUnit) {
+    const fromUnitIdentifier = DistanceConverter.getUnitConversionIdentifier(distance.unit);
+    const toUnitIdentifier = DistanceConverter.getUnitConversionIdentifier(toUnit);
+    const convertedValue = convert(distance.value).from(fromUnitIdentifier).to(toUnitIdentifier);
+
+    switch (toUnit) {
+      case Unit.KILOMETER: {
+        // Note divided by 1000 because convert library does not have kilometers, so using meters
+        return new Distance({
+          value: convertedValue / 1000,
+          unit: Unit.KILOMETER
+        });
+      }
+
+      case Unit.MILE: {
+        return new Distance({
+          value: convertedValue,
+          unit: Unit.MILE
+        });
+      }
+
+      default: {
+        throw new TypeError('Unexpected Unit');
+      }
+    }
+  }
+
+  static getUnitConversionIdentifier(unit) {
+    switch (unit) {
+      case Unit.MILE: {
+        return 'mi';
+      }
+
+      case Unit.KILOMETER: {
+        return 'm';
+      }
+
+      default: {
+        throw new TypeError('Unknown unit');
+      }
+    }
+  }
+}

--- a/src/services/UberService.js
+++ b/src/services/UberService.js
@@ -27,7 +27,7 @@ export default class UberService {
                });
   }
 
-  getPriceEstimates(start, end) {
+  getPriceEstimates(start, end, distanceUnit) {
     let startLocation = this.geocodeService.getLocations(start)
                                            .then(locations => UberService.getFirstLocation(locations));
     let endLocation = this.geocodeService.getLocations(end)
@@ -39,7 +39,7 @@ export default class UberService {
                                            end: values[1].coordinate })
                       .then(response => new PriceEstimates({ start: values[0],
                                                              end: values[1],
-                                                             estimates: PriceEstimatesTranslator.translate(response) }));
+                                                             estimates: PriceEstimatesTranslator.translate(response, distanceUnit) }));
                   });
   }
 

--- a/src/services/UberService.js
+++ b/src/services/UberService.js
@@ -27,10 +27,10 @@ export default class UberService {
                });
   }
 
-  getPriceEstimates(start, end, distanceUnit) {
-    let startLocation = this.geocodeService.getLocations(start)
+  getPriceEstimates(query) {
+    let startLocation = this.geocodeService.getLocations(query.startAddress)
                                            .then(locations => UberService.getFirstLocation(locations));
-    let endLocation = this.geocodeService.getLocations(end)
+    let endLocation = this.geocodeService.getLocations(query.endAddress)
                                          .then(locations => UberService.getFirstLocation(locations));
     return Promise.all([startLocation, endLocation])
                   .then(values => {
@@ -39,7 +39,7 @@ export default class UberService {
                                            end: values[1].coordinate })
                       .then(response => new PriceEstimates({ start: values[0],
                                                              end: values[1],
-                                                             estimates: PriceEstimatesTranslator.translate(response, distanceUnit) }));
+                                                             estimates: PriceEstimatesTranslator.translate(response, query.distanceUnit) }));
                   });
   }
 

--- a/src/services/tables/builders/PriceEstimateFormatter.js
+++ b/src/services/tables/builders/PriceEstimateFormatter.js
@@ -1,0 +1,35 @@
+'use es6';
+
+import CurrencySymbol from 'currency-symbol-map';
+
+import DistanceUnit from '../../../data/DistanceUnit';
+import DistanceConverter from '../../DistanceConverter';
+
+export default class PriceEstimateFormatter {
+  static getFormattedRange(range) {
+    const currencySymbol = CurrencySymbol(range.currencyCode);
+    return `${currencySymbol}${range.low}-${currencySymbol}${range.high}`;
+  }
+
+  static getFormattedDistance(distance) {
+    // 2 decimal places
+    const roundedDistanceValue = Math.round(distance.value * 100) / 100;
+    return `${roundedDistanceValue} ${PriceEstimateFormatter.getDistanceUnitAbbreviation(distance.unit)}.`;
+  }
+
+  static getDistanceUnitAbbreviation(unit) {
+    switch (unit) {
+      case DistanceUnit.MILE: {
+        return 'mi';
+      }
+
+      case DistanceUnit.KILOMETER: {
+        return 'km';
+      }
+
+      default: {
+        throw new TypeError('Unexpected distance unit');
+      }
+    }
+  }
+}

--- a/src/services/tables/builders/PriceEstimateFormatter.js
+++ b/src/services/tables/builders/PriceEstimateFormatter.js
@@ -11,7 +11,7 @@ export default class PriceEstimateFormatter {
     return `${currencySymbol}${range.low}-${currencySymbol}${range.high}`;
   }
 
-  static getFormattedDistance(distance) {
+  static formatDistance(distance) {
     // 2 decimal places
     const roundedDistanceValue = Math.round(distance.value * 100) / 100;
     return `${roundedDistanceValue} ${PriceEstimateFormatter.getDistanceUnitAbbreviation(distance.unit)}.`;

--- a/src/services/tables/builders/PriceEstimatesTableBuilder.js
+++ b/src/services/tables/builders/PriceEstimatesTableBuilder.js
@@ -4,6 +4,7 @@ import emoji from 'node-emoji';
 import {List,Map} from 'immutable';
 import Table from 'cli-table2';
 
+import PriceEstimateFormatter from './PriceEstimateFormatter';
 import Utilities from '../../../Utilities';
 
 export default class PriceEstimatesTableBuilder {
@@ -41,7 +42,7 @@ export default class PriceEstimatesTableBuilder {
     return [
       estimate.productName,
       estimate.getFormattedRange(),
-      estimate.getFormattedDistance(),
+      PriceEstimateFormatter.formatDistance(estimate.distance),
       Utilities.generateFormattedTime(estimate.duration),
       PriceEstimatesTableBuilder.buildSurgeMultiplierSymbol(estimate.surgeMultiplier)
     ];

--- a/src/services/translators/PriceEstimatesTranslator.js
+++ b/src/services/translators/PriceEstimatesTranslator.js
@@ -2,12 +2,15 @@
 
 import {List, Map} from 'immutable';
 
+import Distance from '../../data/Distance';
+import DistanceConverter from '../DistanceConverter';
+import DistanceUnit from '../../data/DistanceUnit';
 import PriceEstimate from '../../data/PriceEstimate';
 import Range from '../../data/Range';
 import Utilities from '../../Utilities';
 
 export default class PriceEstimatesTranslator {
-  static translate(response) {
+  static translate(response, distanceUnit) {
     if (!('prices' in response)) {
       throw new ReferenceError('expected prices field');
     }
@@ -17,10 +20,10 @@ export default class PriceEstimatesTranslator {
       throw new TypeError('expected prices to be an array');
     }
 
-    return List(estimates.map(estimate => PriceEstimatesTranslator.translateEstimate(estimate)));
+    return List(estimates.map(estimate => PriceEstimatesTranslator.translateEstimate(estimate, distanceUnit)));
   }
 
-  static translateEstimate(estimate) {
+  static translateEstimate(estimate, distanceUnit) {
     if (!('localized_display_name' in estimate)) {
       throw new ReferenceError('expected localized display name field');
     }
@@ -50,8 +53,8 @@ export default class PriceEstimatesTranslator {
       throw new TypeError('expected localized display name to be a string');
     }
 
-    let distance = estimate['distance'];
-    if (!Utilities.isFloat(distance)) {
+    let distanceValue = estimate['distance'];
+    if (!Utilities.isFloat(distanceValue)) {
       throw new TypeError('expected distance to be an integer');
     }
 
@@ -84,9 +87,17 @@ export default class PriceEstimatesTranslator {
       throw new TypeError('expected currency code name to be a string');
     }
 
+    // Uber returns miles
+    // // https://developer.uber.com/docs/riders/references/api/v1.2/estimates-price-get
+    const mileDistance = new Distance({
+      value: distanceValue,
+      unit: DistanceUnit.MILE
+    });
+    const convertedDistance = DistanceConverter.convert(mileDistance, distanceUnit);
+
     let args = Map({
       productName: displayName,
-      distance: distance,
+      distance: convertedDistance,
       duration: duration,
       range: new Range({
         high: highEstimate,

--- a/src/services/translators/PriceEstimatesTranslator.js
+++ b/src/services/translators/PriceEstimatesTranslator.js
@@ -89,11 +89,11 @@ export default class PriceEstimatesTranslator {
 
     // Uber returns miles
     // // https://developer.uber.com/docs/riders/references/api/v1.2/estimates-price-get
-    const mileDistance = new Distance({
+    const distanceInMiles = new Distance({
       value: distanceValue,
       unit: DistanceUnit.MILE
     });
-    const convertedDistance = DistanceConverter.convert(mileDistance, distanceUnit);
+    const convertedDistance = DistanceConverter.convert(distanceInMiles, distanceUnit);
 
     let args = Map({
       productName: displayName,

--- a/test/DistanceConverterTest.js
+++ b/test/DistanceConverterTest.js
@@ -5,7 +5,7 @@ import chaiImmutable from 'chai-immutable';
 
 import Distance from '../src/data/Distance';
 import Range from '../src/data/Range';
-import Unit from '../src/data/Unit';
+import DistanceUnit from '../src/data/DistanceUnit';
 
 import DistanceConverter from '../src/services/DistanceConverter';
 
@@ -15,23 +15,23 @@ let expect = chai.expect;
 
 describe('Distance converter test', function() {
   describe('Unit identifier test', function() {
-    expect(DistanceConverter.getUnitConversionIdentifier(Unit.MILE)).to.equal('mi');
-    expect(DistanceConverter.getUnitConversionIdentifier(Unit.KILOMETER)).to.equal('m');
+    expect(DistanceConverter.getUnitConversionIdentifier(DistanceUnit.MILE)).to.equal('mi');
+    expect(DistanceConverter.getUnitConversionIdentifier(DistanceUnit.KILOMETER)).to.equal('m');
   });
 
   const distance = 1.234;
   const kilometerDistance = 1.9858335873209383;
   const distanceInMiles = new Distance({
     value: distance,
-    unit: Unit.MILE
+    unit: DistanceUnit.MILE
   });
   const distanceInKilometers = new Distance({
     value: kilometerDistance,
-    unit: Unit.KILOMETER
+    unit: DistanceUnit.KILOMETER
   });
 
   describe('Distance conversion test', function() {
-    expect(DistanceConverter.convert(distanceInMiles, Unit.MILE)).to.eql(distanceInMiles);
-    expect(DistanceConverter.convert(distanceInMiles, Unit.KILOMETER)).to.eql(distanceInKilometers);
+    expect(DistanceConverter.convert(distanceInMiles, DistanceUnit.MILE)).to.eql(distanceInMiles);
+    expect(DistanceConverter.convert(distanceInMiles, DistanceUnit.KILOMETER)).to.eql(distanceInKilometers);
   });
 });

--- a/test/DistanceConverterTest.js
+++ b/test/DistanceConverterTest.js
@@ -1,0 +1,37 @@
+'use es6';
+
+import chai from 'chai';
+import chaiImmutable from 'chai-immutable';
+
+import Distance from '../src/data/Distance';
+import Range from '../src/data/Range';
+import Unit from '../src/data/Unit';
+
+import DistanceConverter from '../src/services/DistanceConverter';
+
+chai.use(chaiImmutable);
+
+let expect = chai.expect;
+
+describe('Distance converter test', function() {
+  describe('Unit identifier test', function() {
+    expect(DistanceConverter.getUnitConversionIdentifier(Unit.MILE)).to.equal('mi');
+    expect(DistanceConverter.getUnitConversionIdentifier(Unit.KILOMETER)).to.equal('m');
+  });
+
+  const distance = 1.234;
+  const kilometerDistance = 1.9858335873209383;
+  const distanceInMiles = new Distance({
+    value: distance,
+    unit: Unit.MILE
+  });
+  const distanceInKilometers = new Distance({
+    value: kilometerDistance,
+    unit: Unit.KILOMETER
+  });
+
+  describe('Distance conversion test', function() {
+    expect(DistanceConverter.convert(distanceInMiles, Unit.MILE)).to.eql(distanceInMiles);
+    expect(DistanceConverter.convert(distanceInMiles, Unit.KILOMETER)).to.eql(distanceInKilometers);
+  });
+});

--- a/test/PriceEstimateQueryTest.js
+++ b/test/PriceEstimateQueryTest.js
@@ -1,0 +1,40 @@
+'use es6';
+
+import chai from 'chai';
+import chaiImmutable from 'chai-immutable';
+
+import PriceEstimateQuery from '../src/data/PriceEstimateQuery';
+import DistanceUnit from '../src/data/DistanceUnit';
+
+chai.use(chaiImmutable);
+
+let expect = chai.expect;
+
+describe('Test Price Estimate Query', function() {
+  const startAddress = 'foo';
+  const endAddress = 'bar';
+
+  it('Should return kilometer distance unit', function() {
+    const expectedQuery = new PriceEstimateQuery({
+      startAddress: startAddress,
+      endAddress: endAddress,
+      distanceUnit: DistanceUnit.KILOMETER
+    });
+    const calculatedQuery = PriceEstimateQuery.from(startAddress, endAddress, DistanceUnit.KILOMETER.name);
+    expect(calculatedQuery).to.eql(expectedQuery);
+  });
+
+  it('Should return mile distance unit in default case', function() {
+    const expectedQuery = new PriceEstimateQuery({
+      startAddress: startAddress,
+      endAddress: endAddress,
+      distanceUnit: DistanceUnit.MILE
+    });
+    const calculatedQuery = PriceEstimateQuery.from(startAddress, endAddress, undefined);
+    expect(calculatedQuery).to.eql(expectedQuery);
+  });
+
+  it('Should throw when it cannot identify a non-undefined distance unit', function() {
+    expect( () => PriceEstimateQuery.from(startAddress, endAddress, 1) ).to.throw(TypeError);
+  });
+});

--- a/test/PriceEstimatesTableBuilderTest.js
+++ b/test/PriceEstimatesTableBuilderTest.js
@@ -5,13 +5,15 @@ import {expect} from 'chai';
 import {List, Map} from 'immutable';
 
 import Coordinate from '../src/data/Coordinate';
+import Distance from '../src/data/Distance';
+import DistanceUnit from '../src/data/DistanceUnit';
 import Location from '../src/data/Location';
 import PriceEstimate from '../src/data/PriceEstimate';
 import PriceEstimates from '../src/data/PriceEstimates';
 import PriceEstimatesTableBuilder from '../src/services/tables/builders/PriceEstimatesTableBuilder';
 import Range from '../src/data/Range';
 
-describe('Test Time Estimates Table Builder', function() {
+describe('Test Price Estimates Table Builder', function() {
   let start = new Location({
     name: 'start location name',
     coordinate: new Coordinate()
@@ -23,7 +25,10 @@ describe('Test Time Estimates Table Builder', function() {
   let estimates = List.of(
     new PriceEstimate({
       productName: 'jae',
-      distance: 1,
+      distance: new Distance({
+        value: 1,
+        unit: DistanceUnit.MILE
+      }),
       range: new Range({
         low: 2,
         high: 3
@@ -34,7 +39,10 @@ describe('Test Time Estimates Table Builder', function() {
     }),
     new PriceEstimate({
       productName: 'bradley',
-      distance: 5,
+      distance: new Distance({
+        value: 5,
+        unit: DistanceUnit.MILE
+      }),
       range: new Range({
         low: 6,
         high: 7
@@ -45,7 +53,10 @@ describe('Test Time Estimates Table Builder', function() {
     }),
     new PriceEstimate({
       productName: 'baebae',
-      distance: 9,
+      distance: new Distance({
+        value: 9,
+        unit: DistanceUnit.MILE
+      }),
       range: new Range({
         low: 10,
         high: 11

--- a/test/PriceEstimatesTranslatorTest.js
+++ b/test/PriceEstimatesTranslatorTest.js
@@ -4,6 +4,8 @@ import chai from 'chai';
 import chaiImmutable from 'chai-immutable';
 import {List} from 'immutable';
 
+import Distance from '../src/data/Distance';
+import DistanceUnit from '../src/data/DistanceUnit';
 import PriceEstimate from '../src/data/PriceEstimate';
 import PriceEstimatesTranslator from '../src/services/translators/PriceEstimatesTranslator';
 import Range from '../src/data/Range';
@@ -14,7 +16,11 @@ let expect = chai.expect;
 
 describe('Test Price Estimates Translator', function() {
   let localizedDisplayName = 'jae';
-  let distance = 1.234;
+  const distanceValue = 1.234;
+  const distance = new Distance({
+    value: distanceValue,
+    unit: DistanceUnit.MILE
+  });
   let highEstimate = 2;
   let lowEstimate = 3;
   let duration = 4;
@@ -22,7 +28,7 @@ describe('Test Price Estimates Translator', function() {
   let surgeMultiplier = 5.678;
   let baseJson = {
     'localized_display_name': localizedDisplayName,
-    'distance': distance,
+    'distance': distanceValue,
     'high_estimate': highEstimate,
     'low_estimate': lowEstimate,
     'duration': duration,
@@ -40,7 +46,7 @@ describe('Test Price Estimates Translator', function() {
       }),
       currencyCode: currencyCode
     });
-    expect(PriceEstimatesTranslator.translateEstimate(baseJson)).to.eql(expectedEstimate);
+    expect(PriceEstimatesTranslator.translateEstimate(baseJson, DistanceUnit.MILE)).to.eql(expectedEstimate);
   });
 
   it('tests price estimate translation with surge', function() {
@@ -57,53 +63,53 @@ describe('Test Price Estimates Translator', function() {
       currencyCode: currencyCode,
       surgeMultiplier: surgeMultiplier
     });
-    expect(PriceEstimatesTranslator.translateEstimate(json)).to.eql(expectedEstimate);
+    expect(PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.eql(expectedEstimate);
   });
 
   it('tests price estimates translation error cases', function() {
     let json = {};
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(ReferenceError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(ReferenceError);
     json['localized_display_name'] = undefined;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(ReferenceError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(ReferenceError);
     json['distance'] = undefined;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(ReferenceError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(ReferenceError);
     json['high_estimate'] = undefined;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(ReferenceError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(ReferenceError);
     json['low_estimate'] = undefined;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(ReferenceError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(ReferenceError);
     json['duration'] = undefined;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(ReferenceError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(ReferenceError);
     json['currency_code'] = undefined;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(TypeError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(TypeError);
     json['localized_display_name'] = localizedDisplayName;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(TypeError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(TypeError);
     json['distance'] = distance;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(TypeError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(TypeError);
     json['duration'] = duration;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(TypeError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(TypeError);
     json['high_estimate'] = highEstimate;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(TypeError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(TypeError);
     json['low_estimate'] = lowEstimate;
 
-    expect(() => PriceEstimatesTranslator.translateEstimate(json)).to.throw(TypeError);
+    expect(() => PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.throw(TypeError);
   });
 
   it('tests full translation error cases', function() {
     let json = {};
-    expect(() => PriceEstimatesTranslator.translate(json)).to.throw(ReferenceError);
+    expect(() => PriceEstimatesTranslator.translate(json, DistanceUnit.MILE)).to.throw(ReferenceError);
 
     json['prices'] = undefined;
-    expect(() => PriceEstimatesTranslator.translate(json)).to.throw(TypeError);
+    expect(() => PriceEstimatesTranslator.translate(json, DistanceUnit.MILE)).to.throw(TypeError);
   });
 });

--- a/test/UberServiceTest.js
+++ b/test/UberServiceTest.js
@@ -6,6 +6,7 @@ import chaiImmutable from 'chai-immutable';
 
 import {List} from 'immutable';
 
+import PriceEstimateQuery from '../src/data/PriceEstimateQuery';
 import UberService from '../src/services/UberService';
 import TimeEstimate from '../src/data/TimeEstimate';
 import DistanceUnit from '../src/data/DistanceUnit';
@@ -18,6 +19,11 @@ describe('Test Uber Service', function() {
   let service = new UberService();
   let address = '25 first street cambridge ma';
   let address2 = '114 line street somerville ma';
+  let priceEstimateQuery = new PriceEstimateQuery({
+    startAddress: address,
+    endAddress: address2,
+    distanceUnit: DistanceUnit.MILE
+  });
 
   it('tests time estimates fulfillment', function() {
     return service.getTimeEstimates(address).should.be.fulfilled;
@@ -29,11 +35,11 @@ describe('Test Uber Service', function() {
   });
 
   it('tests price estimates fulfillment', function() {
-    return service.getPriceEstimates(address, address2, DistanceUnit.MILE).should.be.fulfilled;
+    return service.getPriceEstimates(priceEstimateQuery).should.be.fulfilled;
   })
 
   it('tests price estimates fetching', function() {
-    return service.getPriceEstimates(address, address2, DistanceUnit.MILE)
+    return service.getPriceEstimates(priceEstimateQuery)
                   .then(results => console.log(results));
   });
 });

--- a/test/UberServiceTest.js
+++ b/test/UberServiceTest.js
@@ -8,6 +8,7 @@ import {List} from 'immutable';
 
 import UberService from '../src/services/UberService';
 import TimeEstimate from '../src/data/TimeEstimate';
+import DistanceUnit from '../src/data/DistanceUnit';
 
 chai.use(chaiAsPromised);
 chai.use(chaiImmutable);
@@ -28,11 +29,11 @@ describe('Test Uber Service', function() {
   });
 
   it('tests price estimates fulfillment', function() {
-    return service.getPriceEstimates(address, address2).should.be.fulfilled;
+    return service.getPriceEstimates(address, address2, DistanceUnit.MILE).should.be.fulfilled;
   })
 
   it('tests price estimates fetching', function() {
-    return service.getPriceEstimates(address, address2)
+    return service.getPriceEstimates(address, address2, DistanceUnit.MILE)
                   .then(results => console.log(results));
   });
 });


### PR DESCRIPTION
Resolves #23 

### Purpose
Adds the ability to choose a distance unit for price estimates by specifying the unit after the `-u` flag.

So something like `uber price -s 'some start address' -e 'some end address' -u kilometer` or `uber price -s 'some start address' -e 'some end address' -u mile`. The default unit is mile.

I get that typing out `kilometer` might be verbose, and some people might argue that `km` is a more reasonable value, but I prefer to be more specific initially, and if it's something people are really clamoring for then I can add it later