### PR TITLE
Implement new price estimate range formatter and update range class

### DIFF
--- a/src/data/PriceEstimate.js
+++ b/src/data/PriceEstimate.js
@@ -4,12 +4,12 @@ import {Record} from 'immutable';
 import CurrencySymbol from 'currency-symbol-map';
 
 import Distance from './Distance';
-import Range from './Range';
+import PriceRange from './PriceRange';
 
 let defaults = {
   productName: '',
   distance: new Distance(),
-  range: new Range(),
+  range: new PriceRange(),
   // in seconds
   duration: 0,
   currencyCode: '',

--- a/src/data/PriceEstimate.js
+++ b/src/data/PriceEstimate.js
@@ -12,7 +12,6 @@ let defaults = {
   range: new PriceRange(),
   // in seconds
   duration: 0,
-  currencyCode: '',
   // wont show up unless > 1
   surgeMultiplier: 1
 };

--- a/src/data/PriceEstimate.js
+++ b/src/data/PriceEstimate.js
@@ -17,7 +17,4 @@ let defaults = {
 };
 
 export default class PriceEstimate extends Record(defaults) {
-  getFormattedRange() {
-    return `${CurrencySymbol(this.currencyCode)}${this.range.low}-${CurrencySymbol(this.currencyCode)}${this.range.high}`;
-  }
 }

--- a/src/data/PriceRange.js
+++ b/src/data/PriceRange.js
@@ -5,7 +5,8 @@ import {Record} from 'immutable';
 let defaults = {
   low: 0,
   high: 0,
+  currencyCode: 'USD'
 };
 
-export default class Range extends Record(defaults){
+export default class PriceRange extends Record(defaults){
 };

--- a/src/services/tables/builders/PriceEstimateFormatter.js
+++ b/src/services/tables/builders/PriceEstimateFormatter.js
@@ -6,7 +6,7 @@ import DistanceUnit from '../../../data/DistanceUnit';
 import DistanceConverter from '../../DistanceConverter';
 
 export default class PriceEstimateFormatter {
-  static getFormattedRange(range) {
+  static formatRange(range) {
     const currencySymbol = CurrencySymbol(range.currencyCode);
     return `${currencySymbol}${range.low}-${currencySymbol}${range.high}`;
   }

--- a/src/services/tables/builders/PriceEstimatesTableBuilder.js
+++ b/src/services/tables/builders/PriceEstimatesTableBuilder.js
@@ -41,7 +41,7 @@ export default class PriceEstimatesTableBuilder {
   static buildEstimateRow(estimate) {
     return [
       estimate.productName,
-      estimate.getFormattedRange(),
+      PriceEstimateFormatter.formatRange(estimate.range),
       PriceEstimateFormatter.formatDistance(estimate.distance),
       Utilities.generateFormattedTime(estimate.duration),
       PriceEstimatesTableBuilder.buildSurgeMultiplierSymbol(estimate.surgeMultiplier)

--- a/src/services/translators/PriceEstimatesTranslator.js
+++ b/src/services/translators/PriceEstimatesTranslator.js
@@ -6,7 +6,7 @@ import Distance from '../../data/Distance';
 import DistanceConverter from '../DistanceConverter';
 import DistanceUnit from '../../data/DistanceUnit';
 import PriceEstimate from '../../data/PriceEstimate';
-import Range from '../../data/Range';
+import PriceRange from '../../data/PriceRange';
 import Utilities from '../../Utilities';
 
 export default class PriceEstimatesTranslator {
@@ -99,9 +99,10 @@ export default class PriceEstimatesTranslator {
       productName: displayName,
       distance: convertedDistance,
       duration: duration,
-      range: new Range({
+      range: new PriceRange({
         high: highEstimate,
-        low: lowEstimate
+        low: lowEstimate,
+        currencyCode: currencyCode
       }),
       currencyCode: currencyCode
     });

--- a/src/services/translators/PriceEstimatesTranslator.js
+++ b/src/services/translators/PriceEstimatesTranslator.js
@@ -103,8 +103,7 @@ export default class PriceEstimatesTranslator {
         high: highEstimate,
         low: lowEstimate,
         currencyCode: currencyCode
-      }),
-      currencyCode: currencyCode
+      })
     });
 
     // wont show up unless > 1

--- a/test/DistanceConverterTest.js
+++ b/test/DistanceConverterTest.js
@@ -4,7 +4,6 @@ import chai from 'chai';
 import chaiImmutable from 'chai-immutable';
 
 import Distance from '../src/data/Distance';
-import Range from '../src/data/Range';
 import DistanceUnit from '../src/data/DistanceUnit';
 
 import DistanceConverter from '../src/services/DistanceConverter';

--- a/test/PriceEstimatesTableBuilderTest.js
+++ b/test/PriceEstimatesTableBuilderTest.js
@@ -11,7 +11,7 @@ import Location from '../src/data/Location';
 import PriceEstimate from '../src/data/PriceEstimate';
 import PriceEstimates from '../src/data/PriceEstimates';
 import PriceEstimatesTableBuilder from '../src/services/tables/builders/PriceEstimatesTableBuilder';
-import Range from '../src/data/Range';
+import PriceRange from '../src/data/PriceRange';
 
 describe('Test Price Estimates Table Builder', function() {
   let start = new Location({
@@ -29,9 +29,10 @@ describe('Test Price Estimates Table Builder', function() {
         value: 1,
         unit: DistanceUnit.MILE
       }),
-      range: new Range({
+      range: new PriceRange({
         low: 2,
-        high: 3
+        high: 3,
+        currencyCode: 'USD'
       }),
       duration: 4,
       currencyCode: 'USD',
@@ -43,9 +44,10 @@ describe('Test Price Estimates Table Builder', function() {
         value: 5,
         unit: DistanceUnit.MILE
       }),
-      range: new Range({
+      range: new PriceRange({
         low: 6,
-        high: 7
+        high: 7,
+        currencyCode: 'GBP'
       }),
       duration: 8,
       currencyCode: 'GBP',
@@ -57,9 +59,10 @@ describe('Test Price Estimates Table Builder', function() {
         value: 9,
         unit: DistanceUnit.MILE
       }),
-      range: new Range({
+      range: new PriceRange({
         low: 10,
-        high: 11
+        high: 11,
+        currencyCode: 'EUR'
       }),
       duration: 12,
       currencyCode: 'EUR',

--- a/test/PriceEstimatesTableBuilderTest.js
+++ b/test/PriceEstimatesTableBuilderTest.js
@@ -35,7 +35,6 @@ describe('Test Price Estimates Table Builder', function() {
         currencyCode: 'USD'
       }),
       duration: 4,
-      currencyCode: 'USD',
       surgeMultiplier: 1
     }),
     new PriceEstimate({
@@ -50,7 +49,6 @@ describe('Test Price Estimates Table Builder', function() {
         currencyCode: 'GBP'
       }),
       duration: 8,
-      currencyCode: 'GBP',
       surgeMultiplier: 1.1
     }),
     new PriceEstimate({
@@ -65,7 +63,6 @@ describe('Test Price Estimates Table Builder', function() {
         currencyCode: 'EUR'
       }),
       duration: 12,
-      currencyCode: 'EUR',
       surgeMultiplier: 13
     }),
   );

--- a/test/PriceEstimatesTranslatorTest.js
+++ b/test/PriceEstimatesTranslatorTest.js
@@ -8,7 +8,7 @@ import Distance from '../src/data/Distance';
 import DistanceUnit from '../src/data/DistanceUnit';
 import PriceEstimate from '../src/data/PriceEstimate';
 import PriceEstimatesTranslator from '../src/services/translators/PriceEstimatesTranslator';
-import Range from '../src/data/Range';
+import PriceRange from '../src/data/PriceRange';
 
 chai.use(chaiImmutable);
 
@@ -40,9 +40,10 @@ describe('Test Price Estimates Translator', function() {
       productName: localizedDisplayName,
       distance: distance,
       duration: duration,
-      range: new Range({
+      range: new PriceRange({
         high: highEstimate,
-        low: lowEstimate
+        low: lowEstimate,
+        currencyCode: currencyCode
       }),
       currencyCode: currencyCode
     });
@@ -56,9 +57,10 @@ describe('Test Price Estimates Translator', function() {
       productName: localizedDisplayName,
       distance: distance,
       duration: duration,
-      range: new Range({
+      range: new PriceRange({
         high: highEstimate,
-        low: lowEstimate
+        low: lowEstimate,
+        currencyCode: currencyCode
       }),
       currencyCode: currencyCode,
       surgeMultiplier: surgeMultiplier

--- a/test/PriceEstimatesTranslatorTest.js
+++ b/test/PriceEstimatesTranslatorTest.js
@@ -44,8 +44,7 @@ describe('Test Price Estimates Translator', function() {
         high: highEstimate,
         low: lowEstimate,
         currencyCode: currencyCode
-      }),
-      currencyCode: currencyCode
+      })
     });
     expect(PriceEstimatesTranslator.translateEstimate(baseJson, DistanceUnit.MILE)).to.eql(expectedEstimate);
   });
@@ -62,7 +61,6 @@ describe('Test Price Estimates Translator', function() {
         low: lowEstimate,
         currencyCode: currencyCode
       }),
-      currencyCode: currencyCode,
       surgeMultiplier: surgeMultiplier
     });
     expect(PriceEstimatesTranslator.translateEstimate(json, DistanceUnit.MILE)).to.eql(expectedEstimate);

--- a/test/UtilitiesTest.js
+++ b/test/UtilitiesTest.js
@@ -4,7 +4,6 @@ import {expect} from 'chai';
 
 import PriceEstimate from '../src/data/PriceEstimate';
 import PriceEstimatesTranslator from '../src/services/translators/PriceEstimatesTranslator';
-import Range from '../src/data/Range';
 import Utilities from '../src/Utilities';
 
 describe('Tests Utilities', function() {


### PR DESCRIPTION
# Purpose
Remove range formatting method on `PriceEstimate` and implement the one in `PriceEstimateFormatter`. Additionally, replace `Range` class with `PriceRange` class that contains a `currencyCode`. This `currencyCode` field was previously on the `PriceEstimate` class.